### PR TITLE
feat: 모바일 레이아웃 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -70,6 +70,45 @@
           "caseInsensitive": true
         }
       }
-    ]
+    ],
+    "indent": [
+      "error",
+      2,
+      {
+        "SwitchCase": 1,
+        "VariableDeclarator": 1,
+        "outerIIFEBody": 1,
+        "MemberExpression": 1,
+        "FunctionDeclaration": { "parameters": 1, "body": 1 },
+        "FunctionExpression": { "parameters": 1, "body": 1 },
+        "CallExpression": { "arguments": 1 },
+        "ArrayExpression": 1,
+        "ObjectExpression": 1,
+        "ImportDeclaration": 1,
+        "flatTernaryExpressions": false,
+        "ignoreComments": false,
+        "ignoredNodes": [
+          "JSXElement",
+          "JSXElement > *",
+          "JSXAttribute",
+          "JSXIdentifier",
+          "JSXNamespacedName",
+          "JSXMemberExpression",
+          "JSXSpreadAttribute",
+          "JSXExpressionContainer",
+          "JSXOpeningElement",
+          "JSXClosingElement",
+          "JSXFragment",
+          "JSXOpeningFragment",
+          "JSXClosingFragment",
+          "JSXText",
+          "JSXEmptyExpression",
+          "JSXSpreadChild"
+        ],
+        "offsetTernaryExpressions": true
+      }
+    ],
+    "react/jsx-indent": ["error", 2],
+    "react/jsx-indent-props": ["error", 2]
   }
 }

--- a/src/components/Layout/BottomNavigation.tsx
+++ b/src/components/Layout/BottomNavigation.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+export default function BottomNavigation() {
+  const router = useRouter();
+
+  return (
+    <nav className="fixed bottom-0 w-full max-w-md bg-white border-t">
+      <ul className="flex justify-around items-center h-14">
+        <li className={router.pathname === '/dutch-pay' ? 'text-blue-500' : ''}>
+          <Link href="/dutch-pay" className="flex flex-col items-center p-2">
+            <span className="text-2xl">💰</span>
+            <span className="text-xs mt-1">더치페이</span>
+          </Link>
+        </li>
+        <li className={router.pathname === '/dutch-pay' ? 'text-blue-500' : ''}>
+          <Link href="/roulette" className="flex flex-col items-center p-2">
+            <span className="text-2xl">🎡</span>
+            <span className="text-xs mt-1">룰렛</span>
+          </Link>
+        </li>
+        <li className={router.pathname === '/dutch-pay' ? 'text-blue-500' : ''}>
+          <Link href="/where-to-meet" className="flex flex-col items-center p-2">
+            <span className="text-2xl">📍</span>
+            <span className="text-xs mt-1">만날 곳</span>
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,16 @@
+import BottomNavigation from '@/components/Layout/BottomNavigation';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  return (
+    <div className="w-full max-w-md min-h-screen flex flex-col bg-[#f6f6f6] shadow-lg overflow-auto">
+      <main className="flex-grow pb-14">
+        {children}
+      </main>
+      <BottomNavigation />
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,16 @@
 import type { AppProps } from 'next/app';
 import localFont from 'next/font/local';
+import Layout from '@/components/Layout';
 import '@/styles/globals.css';
 
 const PretendardVariable = localFont({ src: './assets/fonts/PretendardVariable.woff2' });
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <main className={PretendardVariable.className}>
-      <Component {...pageProps} />
-    </main>
+    <div className={`${PretendardVariable.className} bg-[#e2e1dc] min-h-screen flex items-center justify-center`}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </div>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,31 +1,8 @@
-import { Inter } from 'next/font/google';
-import Link from 'next/link';
-
-const inter = Inter({ subsets: ['latin'] });
-
 export default function Home() {
   return (
-    <main className={`flex min-h-screen flex-col items-center justify-between ${inter.className}`}>
-      <div className="box-border flex h-14 w-lvw items-center border-b-2 border-black pl-10">
-        <Link
-          className="flex h-full items-center px-2 text-lg font-semibold hover:bg-button-blue hover:text-white"
-          href={'/dutch-pay'}
-        >
-          더치페이
-        </Link>
-        <Link
-          className="flex h-full items-center px-2 text-lg font-semibold hover:bg-button-blue hover:text-white"
-          href={'/roulette'}
-        >
-          룰렛 돌리기
-        </Link>
-        <Link
-          className="flex h-full items-center px-2 text-lg font-semibold hover:bg-button-blue hover:text-white"
-          href={'/where-to-meet'}
-        >
-          어디서 만날까?
-        </Link>
-      </div>
-    </main>
+    <>
+      <h1 className="text-2xl font-bold mb-4">환영합니다!</h1>
+      <p>원하시는 기능을 선택해주세요.</p>
+    </>
   );
 }


### PR DESCRIPTION
## ✨ 요약

- 모바일 너비 제한 레이아웃 생성
- 링크를 바텀 네비게이션으로 이동
- 각 컴포넌트 역할 나눔
  - _app: 전체 배경(회색), 폰트
  - Layout: 너비 제한
  - BottomNavigation: fixed, 주요 기능 링크
  - /index: 다른 컴포넌트에 역할 배분 후 현재 의미 없음

<br>

<img width="910" alt="image" src="https://github.com/user-attachments/assets/480fd6d6-b9ca-4240-805e-9d02567ee7a5">


## 😎 해결한 이슈

- Close #14
